### PR TITLE
Add documentation for renault.ac_set_schedules

### DIFF
--- a/source/_integrations/renault.markdown
+++ b/source/_integrations/renault.markdown
@@ -58,6 +58,39 @@ Cancel A/C on vehicle.
   | ---------------------- | -------- | ----------- |
   | `vehicle`| yes | device_id of the vehicle |
 
+### Action `renault.ac_set_schedules`
+
+Update AC schedule on vehicle.
+
+  | Data attribute | Required | Description | Example |
+  | ---------------------- | -------- | ----------- | ------- |
+  | `vehicle`| yes | device_id of the vehicle | |
+  | `schedules` | yes | Schedule details. Can be a single schedule or a list of schedules | see [example below](#ac_schedule_example) |
+
+Notes:
+
+- `schedules` can be in the form `{'id':1,...}` when updating a single schedules, or in the form `[{'id':1,...},{'id':2,...},...]` when updating multiple schedules within the same call
+- the `id` is compulsory on each `schedule` (should be 1 to 5 depending on the vehicle)
+- the `activated` flag is an optional boolean. If it is not provided, then the existing flag will be kept as is.
+- the `monday` to `sunday` elements are optional. If they are not provided, then the existing settings will be kept for each day. If they are provided as None, then the existing setting will be cleared. If a value is provided, it must conform to this format `{'readyAtTime':'T12:00Z'}` where start time is in UTC format and the duration is in minutes.
+
+<a name="ac_schedule_example">Example</a>:
+
+```yaml
+[
+  { 
+    'id': 1, 
+    'activated': true, 
+    'monday': {'readyAtTime':'T12:00Z'} 
+  }, 
+  { 
+    'id': 2, 
+    'activated': false, 
+    'monday': {'readyAtTime':'T12:00Z'} 
+  },
+]
+```
+
 ### Action `renault.charge_set_schedules`
 
 Update charge schedule on vehicle.


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
This PR adds documentation for the new service that is implemented by https://github.com/home-assistant/core/pull/125006

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logos and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/125006
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards